### PR TITLE
Added a Special Social Media Handler

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -35,3 +35,7 @@ handlers:
 - url: /.*
   script: mirror.app
   secure: optional
+
+- url: /speedyMedia
+  script: SM-mirror-EXT.app
+  secure: optional


### PR DESCRIPTION
Because we all know that's at least some of what you were going to do anyways. :p
Most people will use this proxy to access social media and youtube, so it is logical to cache those sites as most people will be happy that they can load these sites quickly.
